### PR TITLE
fix(logging): Do not throw error if we cannot obtain a image frame

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -432,7 +432,7 @@ bool RobocupPlugin::srvGetImage(rgbd::GetRGBD::Request& req, rgbd::GetRGBD::Resp
 
     if (!image_buffer_.nextImage("/map", image, sensor_pose))
     {
-        ROS_ERROR("Could not capture image");
+        ROS_DEBUG("Could not capture image");
         return true;
     }
 


### PR DESCRIPTION
Use debug when grabbing a frame fails, this happens all the time and is
only for visualization. Apparently, it is not an error.